### PR TITLE
Feature/automated prereleases

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,16 +1,18 @@
 name: Prerelease
 on: 
   push:
-    branches:
-    - main
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+-beta*"
 jobs:
   build:
+    permissions: write-all
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout step
       uses: actions/checkout@v4
+    - name: Exit if not on main branch
+      if: endsWith(github.ref, "main") == false
+      run: exit -1
     - name: Docker login step
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -10,9 +10,9 @@ jobs:
     steps:
     - name: Checkout step
       uses: actions/checkout@v4
-    - name: Exit if not on main branch
-      if: endsWith(github.ref, 'main') == false
-      run: exit -1
+    # - name: Exit if not on main branch
+      # if: endsWith(github.ref, 'main') == false
+      # run: exit -1
     - name: Docker login step
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -17,7 +17,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ GITHUB_TOKEN }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Parse version info from tag
       run: |
         VERSION=${GITHUB_REF:11}

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -10,13 +10,6 @@ jobs:
     steps:
     - name: Checkout step
       uses: actions/checkout@v4
-    - name: Fetch branch
-      run: |
-        branch=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)")
-        echo ::set-env name=BRANCH::$branch
-    - name: Exit if not on main branch
-      if: endsWith(env.BRANCH, 'main') == false
-      run: exit -1
     - name: Docker login step
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -14,7 +14,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.THEDEBRIES_GITHUB_TOKEN }}
+        # password: ${{ GITHUB_TOKEN }}
     - name: Parse version info from tag
       run: |
       # GITHUB_REF is like refs/tags/v*.*.*, so strip the first 11 chars

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,8 +1,8 @@
 name: Prerelease
 on: 
   push:
-    branches:
-    - main
+#    branches:
+#    - main
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+-beta*"
 jobs:
@@ -36,4 +36,4 @@ jobs:
             --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.beta \
             --tag $IMG:${{ env.version_major }}.beta \
             .
-        docker push --all-tags $IMG
+#       docker push --all-tags $IMG

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,0 +1,36 @@
+name: Prerelease
+  on: 
+    push:
+      tags:
+      - "v[0-9]+.[0-9]+.[0-9]+-beta*"
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+    - uses: actions/checkout@v4
+    - name: Parse version info from tag
+      run: |
+      # GITHUB_REF is like refs/tags/v*.*.*, so strip the first 11 chars
+        VERSION=${GITHUB_REF:11}
+        MAJOR=$(echo "$VERSION" | cut -d - -f 1 | cut -d . -f 1)
+        MINOR=$(echo "$VERSION" | cut -d - -f 1 | cut -d . -f 2)
+        PATCH=$(echo "$VERSION" | cut -d - -f 1 | cut -d . -f 3)
+        echo "version=$VERSION" >> $GITHUB_ENV
+        echo "version_major=$MAJOR" >> $GITHUB_ENV
+        echo "version_minor=$MINOR" >> $GITHUB_ENV
+        echo "version_patch=$PATCH" >> $GITHUB_ENV
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    - name: Make Prerelease
+      run: |
+        IMG="ghcr.io/${{github.repository}}"
+        IMG="${IMG@L}" # lower case the image
+        docker build \
+            --tag $IMG:${{ env.version }}.beta \
+            --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.beta \
+            --tag $IMG:${{ env.version_major }}.beta \
+            .
+        docker push --all-tags $IMG

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -11,7 +11,7 @@ jobs:
     - name: Checkout step
       uses: actions/checkout@v4
     - name: Exit if not on main branch
-      if: endsWith(github.ref, "main") == false
+      if: endsWith(github.ref, 'main') == false
       run: exit -1
     - name: Docker login step
       uses: docker/login-action@v3

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -8,6 +8,11 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@v4
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Parse version info from tag
       run: |
       # GITHUB_REF is like refs/tags/v*.*.*, so strip the first 11 chars
@@ -19,11 +24,6 @@ jobs:
         echo "version_major=$MAJOR" >> $GITHUB_ENV
         echo "version_minor=$MINOR" >> $GITHUB_ENV
         echo "version_patch=$PATCH" >> $GITHUB_ENV
-    - uses: docker/login-action@v3
-      with:
-        registry: ghcr.io
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     - name: Make Prerelease
       run: |
         IMG="ghcr.io/${{github.repository}}"

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -34,8 +34,9 @@ jobs:
         IMG="ghcr.io/${{github.repository}}"
         IMG="${IMG@L}" # lower case the image
         docker build \
-            --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.${{ env.version_patch }}.beta \
-            --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.beta \
-            --tag $IMG:${{ env.version_major }}.beta \
+            --tag $IMG:${{ env.version }} \
+            --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.${{ env.version_patch }}.beta.latest \
+            --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.beta.latest \
+            --tag $IMG:${{ env.version_major }}.beta.latest \
             .
         docker push --all-tags $IMG

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -5,6 +5,7 @@ on:
     - "v[0-9]+.[0-9]+.[0-9]+-beta*"
 jobs:
   build:
+    permissions: write-all
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout step

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,11 +1,10 @@
 name: Prerelease
-on: push
-#on: 
-#  push:
-#     branches:
-#     - main
-#    tags:
-#    - "v[0-9]+.[0-9]+.[0-9]+-beta*"
+on: 
+  push:
+    branches:
+    - main
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+-beta*"
 jobs:
   build:
     runs-on: ubuntu-24.04
@@ -37,4 +36,4 @@ jobs:
             --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.beta \
             --tag $IMG:${{ env.version_major }}.beta \
             .
-#       docker push --all-tags $IMG
+        docker push --all-tags $IMG

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,8 +1,8 @@
 name: Prerelease
-  on: 
-    push:
-      tags:
-      - "v[0-9]+.[0-9]+.[0-9]+-beta*"
+on: 
+  push:
+    tags:
+    - "v[0-9]+.[0-9]+.[0-9]+-beta*"
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -7,8 +7,10 @@ jobs:
   build:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
-    - uses: docker/login-action@v3
+    - name: Checkout step
+      uses: actions/checkout@v4
+    - name: Docker login step
+      uses: docker/login-action@v3
       with:
         registry: ghcr.io
         username: ${{ github.actor }}

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,10 +1,11 @@
 name: Prerelease
-on: 
-  push:
-#    branches:
-#    - main
-    tags:
-    - "v[0-9]+.[0-9]+.[0-9]+-beta*"
+on: push
+#on: 
+#  push:
+#     branches:
+#     - main
+#    tags:
+#    - "v[0-9]+.[0-9]+.[0-9]+-beta*"
 jobs:
   build:
     runs-on: ubuntu-24.04

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -1,6 +1,8 @@
 name: Prerelease
 on: 
   push:
+    branches:
+    - main
     tags:
     - "v[0-9]+.[0-9]+.[0-9]+-beta*"
 jobs:
@@ -14,10 +16,9 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        # password: ${{ GITHUB_TOKEN }}
+        password: ${{ GITHUB_TOKEN }}
     - name: Parse version info from tag
       run: |
-      # GITHUB_REF is like refs/tags/v*.*.*, so strip the first 11 chars
         VERSION=${GITHUB_REF:11}
         MAJOR=$(echo "$VERSION" | cut -d - -f 1 | cut -d . -f 1)
         MINOR=$(echo "$VERSION" | cut -d - -f 1 | cut -d . -f 2)

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -10,8 +10,12 @@ jobs:
     steps:
     - name: Checkout step
       uses: actions/checkout@v4
+    - name: Fetch branch
+      run: |
+        branch=$(git branch -r --contains ${{ github.ref }} --format "%(refname:lstrip=3)")
+        echo ::set-env name=BRANCH::$branch
     - name: Exit if not on main branch
-      if: endsWith(github.ref, 'main') == false
+      if: endsWith(env.BRANCH, 'main') == false
       run: exit -1
     - name: Docker login step
       uses: docker/login-action@v3

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -14,7 +14,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ THEDEBRIES_GITHUB_TOKEN }}
+        password: ${{ secrets.THEDEBRIES_GITHUB_TOKEN }}
     - name: Parse version info from tag
       run: |
       # GITHUB_REF is like refs/tags/v*.*.*, so strip the first 11 chars

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -14,7 +14,7 @@ jobs:
       with:
         registry: ghcr.io
         username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
+        password: ${{ THEDEBRIES_GITHUB_TOKEN }}
     - name: Parse version info from tag
       run: |
       # GITHUB_REF is like refs/tags/v*.*.*, so strip the first 11 chars

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -10,9 +10,9 @@ jobs:
     steps:
     - name: Checkout step
       uses: actions/checkout@v4
-    # - name: Exit if not on main branch
-      # if: endsWith(github.ref, 'main') == false
-      # run: exit -1
+    - name: Exit if not on main branch
+      if: endsWith(github.ref, 'main') == false
+      run: exit -1
     - name: Docker login step
       uses: docker/login-action@v3
       with:

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -5,7 +5,6 @@ on:
     - "v[0-9]+.[0-9]+.[0-9]+-beta*"
 jobs:
   build:
-    permissions: write-all
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout step
@@ -34,7 +33,7 @@ jobs:
         IMG="ghcr.io/${{github.repository}}"
         IMG="${IMG@L}" # lower case the image
         docker build \
-            --tag $IMG:${{ env.version }}.beta \
+            --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.${{ env.version_patch }}.beta \
             --tag $IMG:${{ env.version_major }}.${{ env.version_minor }}.beta \
             --tag $IMG:${{ env.version_major }}.beta \
             .


### PR DESCRIPTION
Automate prerelease image generation using git tags.
Workflow triggers on push event with tag in format:
```regex
v[0-9]+.[0-9]+.[0-9]+-beta*
```
~~These images should only be generated on a push event to main (for the time being)~~ Checking for main branch is omitted.

Approving this pull request should trigger the appropriate push event to main, creating an image with version characteristics as visible on the right.