### PR TITLE
Add /feedback endpoint to collect and store user feedback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# auto-generated files
+src/__pycache__
+model/.DS_Store
+.idea
+
+feedback-data/


### PR DESCRIPTION
<img width="729" alt="image" src="https://github.com/user-attachments/assets/6ae1d644-2db2-4c52-89fc-d715bc412791" />

After the user submits the review they are prompted to give feedback on the correctness of the prediction. The feedback (+ review + prediction) is sent to model-service at ```/feedback```. On model-service, ```store_user_feedback()``` handles the requests and stores the feedback in a csv file.
The idea here is that the file could be manually added to the training dataset later.

Depends on: https://github.com/remla25-team20/app/pull/10