### PR TITLE
added logic for exposing word counts (total and encoded)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ package-mode = false
 
 [project]
 name = "model-service"
-version = "0.2.0"
+version = "0.2.1-beta"
 description = "The model-service represents a wrapper service for the released ML model. It has a REST API to expose the model to other components."
 authors = [
     {name = "Team 20"}

--- a/src/model_logic.py
+++ b/src/model_logic.py
@@ -34,4 +34,4 @@ class ModelLogic:
         processed_review = preprocessing._text_process(review)
         processed_input = self.cv.transform([" ".join(processed_review)]).toarray()
         prediction = self.classifier.predict(processed_input)[0]
-        return int(prediction)
+        return len(processed_review), int(sum([sum(row) for row in processed_input])), int(prediction)


### PR DESCRIPTION
Added code for exposing word count metrics through prometheus.

Changes to `model_logic.py`: added two values to output: 
- Raw word count (excluding stopwords)
- Encoded word count (sum over CountVectorizer)

Changes to `app.py`:
* Added Prometheus Counters `word_count_raw` and `word_count_encoded`
* Matched changes to `model_logic.py` mentioned above
* Log relevant values to new Counters

Incremented version number to v0.2.1-beta